### PR TITLE
remove go118

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
           - "1.19"
           - "1.20"
     steps:


### PR DESCRIPTION
- Add goreleaser
- Remove version with Go 1.18 installed
