### PR TITLE
feat: Shrink image by using multistage Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           password: ${{ github.token }}
       - name: Build and Push Image
         if: ${{ matrix.go-version != env.LATEST_GO_VERSION }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           build-args: |
             GO_VERSION=${{ matrix.go-version }}
@@ -45,7 +45,7 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Build and Push 'latest' Image
         if: ${{ matrix.go-version == env.LATEST_GO_VERSION }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           build-args: |
             GO_VERSION=${{ matrix.go-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,35 @@
 # syntax=docker/dockerfile:1
 ARG GO_VERSION
-FROM golang:${GO_VERSION}-alpine AS goimage
-
-FROM ghcr.io/ryboe/alpinecodespace:latest
-
-COPY --from=goimage /usr/local/go/ /usr/local/go/
-
-ENV PATH="${HOME}/go/bin:/usr/local/go/bin:${PATH}"
+FROM golang:${GO_VERSION}-alpine AS build
+ENV CGO_ENABLED="0"
 
 # These are all the tools installed by the "Go: Install/Update Tools"
 # command, plus gofumpt. gofumpt is a stricter gofmt that enforces additional
 # formatting rules for better consistency and readabilty.
-RUN <<-EOT
-  go install github.com/cweill/gotests/gotests@latest
-  go install github.com/fatih/gomodifytags@latest
-  go install github.com/josharian/impl@latest
-  go install github.com/haya14busa/goplay/cmd/goplay@latest
-  go install github.com/go-delve/delve/cmd/dlv@latest
-  go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-  go install golang.org/x/tools/gopls@latest
-  go install mvdan.cc/gofumpt@latest
-  sudo rm -rf $HOME/go/pkg/*
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    <<-EOT
+    go install github.com/cweill/gotests/gotests@latest
+    go install github.com/fatih/gomodifytags@latest
+    go install github.com/josharian/impl@latest
+    go install github.com/haya14busa/goplay/cmd/goplay@latest
+    go install github.com/go-delve/delve/cmd/dlv@latest
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+    go install golang.org/x/tools/gopls@latest
+    go install mvdan.cc/gofumpt@latest
 EOT
+
+
+FROM ghcr.io/ryboe/alpinecodespace:latest
+ENV PATH="/home/vscode/go/bin:/usr/local/go/bin:${PATH}"
+COPY --from=build /usr/local/go/ /usr/local/go/
+COPY --from=build /go/bin/ /home/vscode/go/bin
 
 # Install the latest release of goreleaser.
 RUN <<-EOT
-  wget --quiet --timeout=30 --output-document=- 'https://api.github.com/repos/goreleaser/goreleaser/releases/latest' |
-  jq -r ".assets[] | select(.name | test(\"goreleaser_.*?_x86_64.apk\")).browser_download_url" |
-  wget --quiet --timeout=180 --input-file=- --output-document=/tmp/goreleaser.apk
-  sudo apk add --no-cache --allow-untrusted /tmp/goreleaser.apk
-  rm /tmp/goreleaser.apk
+    wget --quiet --timeout=30 --output-document=- 'https://api.github.com/repos/goreleaser/goreleaser/releases/latest' |
+    jq -r ".assets[] | select(.name | test(\"goreleaser_.*?_x86_64.apk\")).browser_download_url" |
+    wget --quiet --timeout=180 --input-file=- --output-document=/tmp/goreleaser.apk
+    sudo apk add --no-cache --allow-untrusted /tmp/goreleaser.apk
+    rm /tmp/goreleaser.apk
 EOT

--- a/README.md
+++ b/README.md
@@ -49,3 +49,27 @@ These development tools are preinstalled:
     }
 }
 ```
+
+## How To Build Locally
+
+1. Set BuildKit (next-gen docker engine) to be your default image builder:
+
+```sh
+# Build with BuildKit by default. After running this command to install the
+# buildx plugin, you can type `docker build` instead of `docker buildx build`.
+docker buildx install
+
+# --driver docker-container    run BuildKit engine as a container (moby/buildkit:buildx-stable-1)
+# --use                        switch to this new container-based docker engine that you're creating
+# --bootstrap                  start moby/buildkit container after it's "created" (pulled, really)
+docker builder create --driver docker-container --name mybuilder --use --bootstrap
+
+# --load                       save the image to the local filesystem
+# --platform linux/amd64       Codespaces only run on AMD64 processors
+# - < Dockerfile               '-' means "don't tar up the current directory and pass it to BuildKit
+#                              as a build context". We don't need a build context because we don't
+#                              need to copy any files from this repo into the container. The only
+#                              thing we need is the Dockerfile, which we're passing by redirecting
+#                              it to stdin.
+docker image build --load --build-arg GO_VERSION=1.20 --platform linux/amd64 --tag mygocodespace - < Dockerfile
+```


### PR DESCRIPTION
Shrink the image from 1.5 GB to 1.1 GB by building all the go utilities (e.g. `golangci-lint`, `gotests`) in the first stage. Cache the go packages to speed up local builds. Set `CGO_ENABLED=0` to build static binaries, so the go utilities don't depend on anything in the release image. Add docs explaining how to build the image locally with `docker buildx`.
