### PR TITLE
feat: bump go 1.22 -> 1.23

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.21"
           - "1.22"
+          - "1.23"
     steps:
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
@@ -22,7 +22,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - name: Build image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           build-args: |
             GO_VERSION=${{ matrix.go-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,13 @@ name: Weekly Release
 # Build a fresh image every week.
 on:
   schedule:
-    - cron: "0 14 * * 1" # run at 9am eastern US time every Monday
+    - cron: 0 14 * * 1 # run at 9am eastern US time every Monday
   push:
     branches:
       - main
 
 env:
-  LATEST_GO_VERSION: "1.22"
+  LATEST_GO_VERSION: "1.23"
 
 jobs:
   build_and_upload_image:
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.21"
           - "1.22"
+          - "1.23"
     steps:
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3
@@ -30,7 +30,7 @@ jobs:
           password: ${{ github.token }}
       - name: Build and Push Image
         if: ${{ matrix.go-version != env.LATEST_GO_VERSION }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           build-args: |
             GO_VERSION=${{ matrix.go-version }}
@@ -45,7 +45,7 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Build and Push 'latest' Image
         if: ${{ matrix.go-version == env.LATEST_GO_VERSION }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           build-args: |
             GO_VERSION=${{ matrix.go-version }}


### PR DESCRIPTION
Also bump the docker/build-push action v5 -> v6.
