### PR TITLE
docs: add link to alpinelinux.org to README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG GO_VERSION
+ARG GO_VERSION="1.23"
 FROM golang:${GO_VERSION}-alpine AS build
 ENV CGO_ENABLED="0"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gocodespace
 
-An Alpine-based codespace for Go development
+An [Alpine](https://alpinelinux.org)-based codespace for Go development
 
 ## Features
 


### PR DESCRIPTION
Apparently no-op commits don't trigger new GHA builds, so here's a tiny README change.
