### PR TITLE
chore: bump to Go 1.24

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.22"
           - "1.23"
+          - "1.24"
     steps:
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  LATEST_GO_VERSION: "1.23"
+  LATEST_GO_VERSION: "1.24"
 
 jobs:
   build_and_upload_image:
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.22"
           - "1.23"
+          - "1.24"
     steps:
       - name: Set up Docker buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG GO_VERSION="1.23"
+ARG GO_VERSION="1.24"
 FROM golang:${GO_VERSION}-alpine AS build
 ENV CGO_ENABLED="0"
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ These development tools are preinstalled:
 // .devcontainer/devcontainer.json
 {
     "name": "My Go Codespace",
-    "image": "ghcr.io/ryboe/gocodespace:1.23",
+    "image": "ghcr.io/ryboe/gocodespace:1.24",
     // dlv needs these capabilities. It needs to run the ptrace (process trace)
     // syscall, and we need to disable the default seccomp profile applied to
     // docker containers.
@@ -69,5 +69,5 @@ docker builder create --driver docker-container --name mybuilder --use --bootstr
 #                              need to copy any files from this repo into the container. The only
 #                              thing we need is the Dockerfile, which we're passing by redirecting
 #                              it to stdin.
-docker image build --load --build-arg GO_VERSION=1.23 --platform linux/amd64 --tag mygocodespace - < Dockerfile
+docker image build --load --build-arg GO_VERSION=1.24 --platform linux/amd64 --tag mygocodespace - < Dockerfile
 ```


### PR DESCRIPTION
Only build images for 1.23 and 1.24. Stop building images for 1.22.
